### PR TITLE
Change Scheduler interval-days to a Duration

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
@@ -23,6 +23,8 @@ import play.api.Mode.Mode
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.config.ServicesConfig
 
+import scala.concurrent.duration.FiniteDuration
+
 @Singleton
 class AppConfig @Inject()(val runModeConfiguration: Configuration, environment: Environment) extends ServicesConfig {
 
@@ -34,7 +36,7 @@ class AppConfig @Inject()(val runModeConfiguration: Configuration, environment: 
 
   lazy val daysElapsed: JobConfig = JobConfig(
     LocalTime.parse(getString("scheduler.days-elapsed.run-time")),
-    getInt("scheduler.days-elapsed.interval-days")
+    getDuration("scheduler.days-elapsed.interval").asInstanceOf[FiniteDuration]
   )
 
   private def getBooleanConfig(key: String, default: Boolean): Boolean = {
@@ -50,4 +52,4 @@ class AppConfig @Inject()(val runModeConfiguration: Configuration, environment: 
 
 }
 
-case class JobConfig(elapseTime: LocalTime, intervalDays: Int)
+case class JobConfig(elapseTime: LocalTime, interval: FiniteDuration)

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJob.scala
@@ -43,7 +43,7 @@ class DaysElapsedJob @Inject()(appConfig: AppConfig, caseService: CaseService, b
 
   override val name: String = "DaysElapsed"
 
-  override def interval: FiniteDuration = FiniteDuration(jobConfig.intervalDays, TimeUnit.DAYS)
+  override def interval: FiniteDuration = jobConfig.interval
 
   override def firstRunTime: LocalTime = {
     jobConfig.elapseTime
@@ -72,7 +72,7 @@ class DaysElapsedJob @Inject()(appConfig: AppConfig, caseService: CaseService, b
           Logger.info(s"$msgPrefix Skipped as it is a Bank Holiday")
           successful(())
         case false =>
-          caseService.incrementDaysElapsed(jobConfig.intervalDays).map { modified: Int =>
+          caseService.incrementDaysElapsed(jobConfig.interval.toDays).map { modified: Int =>
             Logger.info(s"$msgPrefix Incremented the Days Elapsed for [$modified] cases")
             ()
           }

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJob.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 @Singleton
 class DaysElapsedJob @Inject()(appConfig: AppConfig, caseService: CaseService, bankHolidaysConnector: BankHolidaysConnector) extends ScheduledJob {
@@ -37,7 +37,7 @@ class DaysElapsedJob @Inject()(appConfig: AppConfig, caseService: CaseService, b
   private implicit val carrier: HeaderCarrier = HeaderCarrier()
   private lazy val jobConfig = appConfig.daysElapsed
   private lazy val weekendDays = Seq(SATURDAY, SUNDAY)
-  private lazy val secondsInADay = 24 * 60 * 60
+  private lazy val secondsInADay = 1.day.toSeconds
 
   override val name: String = "DaysElapsed"
 

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
@@ -27,13 +27,13 @@ class SchedulerDateUtil @Inject()(appConfig: AppConfig) {
 
   private lazy val clock = appConfig.clock
 
-  def nextRun(offset: LocalTime, finiteDuration: FiniteDuration): Instant = {
+  def nextRun(offset: LocalTime, interval: FiniteDuration): Instant = {
     val time = LocalTime.now(clock)
 
     val offsetSeconds: Int = offset.toSecondOfDay
     val currentSeconds: Int = time.toSecondOfDay
 
-    val intervalSeconds: Long = finiteDuration.toSeconds
+    val intervalSeconds: Long = interval.toSeconds
     val deltaSeconds: Int = offsetSeconds - currentSeconds
     val intervalRemainder: Long = deltaSeconds % intervalSeconds
 
@@ -46,13 +46,13 @@ class SchedulerDateUtil @Inject()(appConfig: AppConfig) {
       .toInstant
   }
 
-  def closestRun(offset: LocalTime, finiteDuration: FiniteDuration): Instant = {
+  def closestRun(offset: LocalTime, interval: FiniteDuration): Instant = {
     val time = LocalTime.now(clock)
 
     val offsetSeconds: Int = offset.toSecondOfDay
     val currentSeconds: Int = time.toSecondOfDay
 
-    val intervalSeconds: Long = finiteDuration.toSeconds
+    val intervalSeconds: Long = interval.toSeconds
     val deltaSeconds: Int = offsetSeconds - currentSeconds
     val intervalRemainder: Long = deltaSeconds % intervalSeconds
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -168,6 +168,6 @@ deleteEnabled = true
 scheduler {
   days-elapsed {
     run-time = "23:30"
-    interval-days = 1
+    interval = "1d"
   }
 }

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
@@ -17,13 +17,12 @@
 package uk.gov.hmrc.bindingtariffclassification.config
 
 import java.time.{LocalTime, ZoneId}
-import java.util.concurrent.TimeUnit
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 class AppConfigTest extends UnitSpec with GuiceOneAppPerSuite {
 
@@ -47,7 +46,7 @@ class AppConfigTest extends UnitSpec with GuiceOneAppPerSuite {
         "scheduler.days-elapsed.interval" -> "1d"
       ).daysElapsed
       config.elapseTime shouldBe LocalTime.of(0, 0, 0)
-      config.interval shouldBe FiniteDuration(1, TimeUnit.DAYS)
+      config.interval shouldBe 1.days
     }
 
     "build 'bankHolidaysUrl without port" in {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
@@ -17,10 +17,13 @@
 package uk.gov.hmrc.bindingtariffclassification.config
 
 import java.time.{LocalTime, ZoneId}
+import java.util.concurrent.TimeUnit
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.duration.FiniteDuration
 
 class AppConfigTest extends UnitSpec with GuiceOneAppPerSuite {
 
@@ -41,10 +44,10 @@ class AppConfigTest extends UnitSpec with GuiceOneAppPerSuite {
     "build 'DaysElapsedConfig" in {
       val config = configWith(
         "scheduler.days-elapsed.run-time" -> "00:00",
-        "scheduler.days-elapsed.interval-days" -> "1"
+        "scheduler.days-elapsed.interval" -> "1d"
       ).daysElapsed
       config.elapseTime shouldBe LocalTime.of(0, 0, 0)
-      config.intervalDays shouldBe 1
+      config.interval shouldBe FiniteDuration(1, TimeUnit.DAYS)
     }
 
     "build 'bankHolidaysUrl without port" in {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
@@ -17,10 +17,8 @@
 package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
-import java.util.concurrent.TimeUnit.{DAYS, HOURS}
 
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
 import org.scalatest.BeforeAndAfterEach
@@ -32,7 +30,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
 
@@ -48,29 +46,29 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
   "Scheduled Job" should {
 
     "Configure 'Name'" in {
-      new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).name shouldBe "DaysElapsed"
+      createDaysElapsedJob.name shouldBe "DaysElapsed"
     }
 
     "Configure 'firstRunTime'" in {
       val runTime = LocalTime.of(14, 0)
-      given(appConfig.daysElapsed).willReturn(JobConfig(runTime, FiniteDuration(1, DAYS)))
+      given(appConfig.daysElapsed).willReturn(JobConfig(runTime, 1.day))
 
-      new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).firstRunTime shouldBe runTime
+      createDaysElapsedJob.firstRunTime shouldBe runTime
     }
 
     "Configure 'interval'" in {
-      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(1, DAYS)))
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1.day))
 
-      new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).interval shouldBe FiniteDuration(1, DAYS)
+      createDaysElapsedJob.interval shouldBe 1.day
     }
 
     "Execute" in {
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
-      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(1, DAYS)))
-      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1.day))
+      given(caseService.incrementDaysElapsed(1)).willReturn(Future.successful(2))
 
-      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+      await(createDaysElapsedJob.execute())
 
       verify(caseService).incrementDaysElapsed(1)
     }
@@ -78,33 +76,37 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
     "Execute with decimal interval" in {
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
-      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(12, HOURS)))
-      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 12.hours))
+      given(caseService.incrementDaysElapsed(0.5)).willReturn(Future.successful(2))
 
-      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+      await(createDaysElapsedJob.execute())
 
       verify(caseService).incrementDaysElapsed(0.5)
     }
 
     "Do nothing on a Saturday" in {
       givenTheDateIsFixedAt("2018-12-29T00:00:00")
-      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+      await(createDaysElapsedJob.execute())
       verifyZeroInteractions(caseService)
     }
 
     "Do nothing on a Sunday" in {
       givenTheDateIsFixedAt("2018-12-30T00:00:00")
-      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+      await(createDaysElapsedJob.execute())
       verifyZeroInteractions(caseService)
     }
 
     "Do nothing on a Bank Holiday" in {
       givenABankHolidayOn("2018-12-25")
       givenTheDateIsFixedAt("2018-12-25T00:00:00")
-      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+      await(createDaysElapsedJob.execute())
       verifyZeroInteractions(caseService)
     }
 
+  }
+
+  private def createDaysElapsedJob: DaysElapsedJob = {
+    new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector)
   }
 
   private def givenABankHolidayOn(date: String): Unit = {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
@@ -53,13 +53,13 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
 
     "Configure 'firstRunTime'" in {
       val runTime = LocalTime.of(14, 0)
-      given(appConfig.daysElapsed).willReturn(JobConfig(runTime, 1))
+      given(appConfig.daysElapsed).willReturn(JobConfig(runTime, FiniteDuration(1, DAYS)))
 
       new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).firstRunTime shouldBe runTime
     }
 
     "Configure 'interval'" in {
-      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1))
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(1, DAYS)))
 
       new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).interval shouldBe FiniteDuration(1, DAYS)
     }
@@ -67,7 +67,7 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
     "Execute" in {
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
-      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1))
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(1, DAYS)))
       given(caseService.incrementDaysElapsed(refEq(1))).willReturn(Future.successful(2))
 
       await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
-import java.util.concurrent.TimeUnit.DAYS
+import java.util.concurrent.TimeUnit.{DAYS, HOURS}
 
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
@@ -68,11 +68,22 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
       given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(1, DAYS)))
-      given(caseService.incrementDaysElapsed(refEq(1))).willReturn(Future.successful(2))
+      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
 
       await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
 
       verify(caseService).incrementDaysElapsed(1)
+    }
+
+    "Execute with decimal interval" in {
+      givenItIsNotABankHoliday()
+      givenTheDateIsFixedAt("2018-12-25T12:00:00")
+      given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, FiniteDuration(12, HOURS)))
+      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
+
+      await(new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector).execute())
+
+      verify(caseService).incrementDaysElapsed(0.5)
     }
 
     "Do nothing on a Saturday" in {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/DaysElapsedJobTest.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
 
-import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.{any, anyDouble}
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
 import org.scalatest.BeforeAndAfterEach
@@ -46,29 +46,29 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
   "Scheduled Job" should {
 
     "Configure 'Name'" in {
-      createDaysElapsedJob.name shouldBe "DaysElapsed"
+      newJob.name shouldBe "DaysElapsed"
     }
 
     "Configure 'firstRunTime'" in {
       val runTime = LocalTime.of(14, 0)
       given(appConfig.daysElapsed).willReturn(JobConfig(runTime, 1.day))
 
-      createDaysElapsedJob.firstRunTime shouldBe runTime
+      newJob.firstRunTime shouldBe runTime
     }
 
     "Configure 'interval'" in {
       given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1.day))
 
-      createDaysElapsedJob.interval shouldBe 1.day
+      newJob.interval shouldBe 1.day
     }
 
     "Execute" in {
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
       given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 1.day))
-      given(caseService.incrementDaysElapsed(1)).willReturn(Future.successful(2))
+      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
 
-      await(createDaysElapsedJob.execute())
+      await(newJob.execute())
 
       verify(caseService).incrementDaysElapsed(1)
     }
@@ -77,44 +77,44 @@ class DaysElapsedJobTest extends UnitSpec with MockitoSugar with BeforeAndAfterE
       givenItIsNotABankHoliday()
       givenTheDateIsFixedAt("2018-12-25T12:00:00")
       given(appConfig.daysElapsed).willReturn(JobConfig(LocalTime.MIDNIGHT, 12.hours))
-      given(caseService.incrementDaysElapsed(0.5)).willReturn(Future.successful(2))
+      given(caseService.incrementDaysElapsed(anyDouble())).willReturn(Future.successful(2))
 
-      await(createDaysElapsedJob.execute())
+      await(newJob.execute())
 
       verify(caseService).incrementDaysElapsed(0.5)
     }
 
     "Do nothing on a Saturday" in {
       givenTheDateIsFixedAt("2018-12-29T00:00:00")
-      await(createDaysElapsedJob.execute())
+      await(newJob.execute())
       verifyZeroInteractions(caseService)
     }
 
     "Do nothing on a Sunday" in {
       givenTheDateIsFixedAt("2018-12-30T00:00:00")
-      await(createDaysElapsedJob.execute())
+      await(newJob.execute())
       verifyZeroInteractions(caseService)
     }
 
     "Do nothing on a Bank Holiday" in {
       givenABankHolidayOn("2018-12-25")
       givenTheDateIsFixedAt("2018-12-25T00:00:00")
-      await(createDaysElapsedJob.execute())
+      await(newJob.execute())
       verifyZeroInteractions(caseService)
     }
 
   }
 
-  private def createDaysElapsedJob: DaysElapsedJob = {
+  private def newJob: DaysElapsedJob = {
     new DaysElapsedJob(appConfig, caseService, bankHolidaysConnector)
   }
 
   private def givenABankHolidayOn(date: String): Unit = {
-    when(bankHolidaysConnector.get()(ArgumentMatchers.any[HeaderCarrier])).thenReturn(Seq(LocalDate.parse(date)))
+    when(bankHolidaysConnector.get()(any[HeaderCarrier])).thenReturn(Seq(LocalDate.parse(date)))
   }
 
   private def givenItIsNotABankHoliday(): Unit = {
-    when(bankHolidaysConnector.get()(ArgumentMatchers.any[HeaderCarrier])).thenReturn(Seq.empty)
+    when(bankHolidaysConnector.get()(any[HeaderCarrier])).thenReturn(Seq.empty)
   }
 
   private def givenTheDateIsFixedAt(date: String) : Unit = {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtilTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtilTest.scala
@@ -116,6 +116,11 @@ class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAft
         time("12:00:02"),
         interval(3, SECONDS)
       ) shouldBe instant("2019-01-01T11:59:59")
+
+      util.closestRun(
+        time("12:00:02"),
+        interval(4, SECONDS)
+      ) shouldBe instant("2019-01-01T11:59:58")
     }
 
     "Calculate the closest run date given a run time in the past" in {
@@ -140,6 +145,11 @@ class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAft
         time("11:59:56"),
         interval(3, SECONDS)
       ) shouldBe instant("2019-01-01T11:59:59")
+
+      util.closestRun(
+        time("11:59:58"),
+        interval(4, SECONDS)
+      ) shouldBe instant("2019-01-01T11:59:58")
     }
   }
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtilTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtilTest.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
-import java.util.concurrent.TimeUnit.SECONDS
 
 import org.mockito.BDDMockito.given
 import org.scalatest.BeforeAndAfterEach
@@ -25,7 +24,7 @@ import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.duration.{FiniteDuration, TimeUnit}
+import scala.concurrent.duration._
 
 class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
 
@@ -43,45 +42,45 @@ class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAft
     "Calculate the next run date given a run time of now" in {
       util.nextRun(
         time("12:00"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the next run date given a run time in the future" in {
       util.nextRun(
         time("12:00:09"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the next run date given a run time in the future with Offset" in {
       util.nextRun(
         time("12:00:01"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.nextRun(
         time("12:00:10"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
     }
 
     "Calculate the next run date given a run time in the past" in {
       util.nextRun(
         time("11:59:51"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the next run date given a run time in the past with Offset" in {
       util.nextRun(
         time("11:59:58"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.nextRun(
         time("11:59:52"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
     }
   }
@@ -90,65 +89,65 @@ class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAft
     "Calculate the closest run date given a run time of now" in {
       util.closestRun(
         time("12:00"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the closest run date given a run time in the future" in {
       util.closestRun(
         time("12:00:09"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the closest run date given a run time in the future with Offset" in {
       util.closestRun(
         time("12:00:01"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.closestRun(
         time("12:00:10"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.closestRun(
         time("12:00:02"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T11:59:59")
 
       util.closestRun(
         time("12:00:02"),
-        interval(4, SECONDS)
+        4.seconds
       ) shouldBe instant("2019-01-01T11:59:58")
     }
 
     "Calculate the closest run date given a run time in the past" in {
       util.closestRun(
         time("11:59:51"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:00")
     }
 
     "Calculate the closest run date given a run time in the past with Offset" in {
       util.closestRun(
         time("11:59:58"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.closestRun(
         time("11:59:52"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T12:00:01")
 
       util.closestRun(
         time("11:59:56"),
-        interval(3, SECONDS)
+        3.seconds
       ) shouldBe instant("2019-01-01T11:59:59")
 
       util.closestRun(
         time("11:59:58"),
-        interval(4, SECONDS)
+        4.seconds
       ) shouldBe instant("2019-01-01T11:59:58")
     }
   }
@@ -161,7 +160,4 @@ class SchedulerDateUtilTest extends UnitSpec with MockitoSugar with BeforeAndAft
     LocalTime.parse(datetime)
   }
 
-  private def interval(length: Int, unit: TimeUnit): FiniteDuration = {
-    FiniteDuration(length, unit)
-  }
 }

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerTest.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
-import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorSystem, Cancellable}
 import org.mockito.ArgumentCaptor
@@ -113,7 +112,7 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
     "Run job with valid schedule" in {
       // Given
       givenTheLockSucceeds()
-      given(job.interval) willReturn FiniteDuration(3, TimeUnit.SECONDS)
+      given(job.interval) willReturn 3.seconds
       given(job.firstRunTime) willReturn "12:00"
       given(job.name) willReturn "name"
       given(util.nextRun(job.firstRunTime, job.interval)) willReturn "2018-12-25T12:00:00"
@@ -124,8 +123,8 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
 
       // Then
       val schedule = theSchedule
-      schedule.interval shouldBe FiniteDuration(3, TimeUnit.SECONDS)
-      schedule.initialDelay shouldBe FiniteDuration(0, TimeUnit.SECONDS)
+      schedule.interval shouldBe 3.seconds
+      schedule.initialDelay shouldBe 0.seconds
 
       val lockEvent = theLockEvent
       lockEvent.name shouldBe "name"
@@ -135,7 +134,7 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
     "Run job with valid schedule and future run-date" in {
       // Given
       givenTheLockSucceeds()
-      given(job.interval) willReturn FiniteDuration(3, TimeUnit.SECONDS)
+      given(job.interval) willReturn 3.seconds
       given(job.firstRunTime) willReturn "12:00"
       given(job.name) willReturn "name"
       given(util.nextRun(job.firstRunTime, job.interval)).willReturn("2018-12-25T12:00:20")
@@ -146,8 +145,8 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
 
       // Then
       val schedule = theSchedule
-      schedule.interval shouldBe FiniteDuration(3, TimeUnit.SECONDS)
-      schedule.initialDelay shouldBe FiniteDuration(20, TimeUnit.SECONDS)
+      schedule.interval shouldBe 3.seconds
+      schedule.initialDelay shouldBe 20.seconds
 
       val lockEvent = theLockEvent
       lockEvent.name shouldBe "name"
@@ -157,7 +156,7 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
     "Fail to schedule job given an invalid run date" in {
       // Given
       givenTheLockSucceeds()
-      given(job.interval) willReturn FiniteDuration(3, TimeUnit.SECONDS)
+      given(job.interval) willReturn 3.seconds
       given(job.firstRunTime) willReturn "12:00"
       given(job.name) willReturn "name"
       given(util.nextRun(job.firstRunTime, job.interval)).willReturn("2018-12-25T11:59:59")
@@ -172,7 +171,7 @@ class SchedulerTest extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
     "Not execute the job if the lock fails" in {
       // Given
       givenTheLockFails()
-      given(job.interval) willReturn FiniteDuration(1, TimeUnit.SECONDS)
+      given(job.interval) willReturn 1.seconds
       given(job.firstRunTime) willReturn now
       given(util.nextRun(job.firstRunTime, job.interval)) willReturn "2018-12-25T12:00:00"
 


### PR DESCRIPTION
Means we can have scheduler config e.g. 
```
scheduler {
  days-elapsed {
    run-time = "23:30"
    interval = "1d" // Rather than interval-days=1
  }
}
```