### PR TITLE
Dit 1025 sample return

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.bindingtariffclassification.model
 import java.time.Instant
 
 import uk.gov.hmrc.bindingtariffclassification.model.CaseStatus.CaseStatus
+import uk.gov.hmrc.bindingtariffclassification.model.SampleReturn.SampleReturn
 import uk.gov.hmrc.bindingtariffclassification.model.SampleStatus.SampleStatus
 
 case class Case
@@ -36,6 +37,5 @@ case class Case
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
   sampleStatus: Option[SampleStatus] = None,
-  sampleRequested: Option[Boolean] = None,
-  sampleToBeReturned: Option[Boolean] = None
+  requestedSampleToBeReturned: Option[SampleReturn] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -34,5 +34,5 @@ case class Case
   decision: Option[Decision] = None,
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
-  sample: Option[Sample] = None
+  sample: Sample = Sample()
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.bindingtariffclassification.model
 import java.time.Instant
 
 import uk.gov.hmrc.bindingtariffclassification.model.CaseStatus.CaseStatus
-import uk.gov.hmrc.bindingtariffclassification.model.SampleReturn.SampleReturn
-import uk.gov.hmrc.bindingtariffclassification.model.SampleStatus.SampleStatus
 
 case class Case
 (
@@ -36,6 +34,5 @@ case class Case
   decision: Option[Decision] = None,
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
-  sampleStatus: Option[SampleStatus] = None,
-  requestedSampleToBeReturned: Option[SampleReturn] = None
+  sample: Option[Sample] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -35,5 +35,7 @@ case class Case
   decision: Option[Decision] = None,
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
-  sampleStatus: Option[SampleStatus] = None
+  sampleStatus: Option[SampleStatus] = None,
+  sampleRequested: Option[Boolean] = None,
+  sampleToBeReturned: Option[Boolean] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.bindingtariffclassification.model.CancelReason.CancelReason
 import uk.gov.hmrc.bindingtariffclassification.model.CaseStatus.CaseStatus
 import uk.gov.hmrc.bindingtariffclassification.model.EventType.EventType
 import uk.gov.hmrc.bindingtariffclassification.model.ReferralReason.ReferralReason
+import uk.gov.hmrc.bindingtariffclassification.model.SampleReturn.SampleReturn
 import uk.gov.hmrc.bindingtariffclassification.model.SampleStatus.SampleStatus
 
 case class Event
@@ -159,6 +160,15 @@ case class SampleStatusChange
   override val `type`: EventType.Value = EventType.SAMPLE_STATUS_CHANGE
 }
 
+case class SampleReturnChange
+(
+  override val from: Option[SampleReturn],
+  override val to: Option[SampleReturn],
+  override val comment: Option[String] = None
+) extends FieldChange[Option[SampleReturn]] {
+  override val `type`: EventType.Value = EventType.SAMPLE_RETURN_CHANGE
+}
+
 
 object EventType extends Enumeration {
   type EventType = Value
@@ -173,4 +183,5 @@ object EventType extends Enumeration {
   val QUEUE_CHANGE = Value
   val NOTE = Value
   val SAMPLE_STATUS_CHANGE = Value
+  val SAMPLE_RETURN_CHANGE = Value
 }

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -87,6 +87,7 @@ object MongoFormatters {
   implicit val formatAppealStatusChange: OFormat[AppealStatusChange] = Json.format[AppealStatusChange]
   implicit val formatAppealAdded: OFormat[AppealAdded] = Json.format[AppealAdded]
   implicit val formatSampleStatusChange: OFormat[SampleStatusChange] = Json.format[SampleStatusChange]
+  implicit val formatSampleReturnChange: OFormat[SampleReturnChange] = Json.format[SampleReturnChange]
   implicit val formatExtendedUseStatusChange: OFormat[ExtendedUseStatusChange] = Json.format[ExtendedUseStatusChange]
   implicit val formatAssignmentChange: OFormat[AssignmentChange] = Json.format[AssignmentChange]
   implicit val formatQueueChange: OFormat[QueueChange] = Json.format[QueueChange]
@@ -100,6 +101,7 @@ object MongoFormatters {
     .and[AppealStatusChange](EventType.APPEAL_STATUS_CHANGE.toString)
     .and[AppealAdded](EventType.APPEAL_ADDED.toString)
     .and[SampleStatusChange](EventType.SAMPLE_STATUS_CHANGE.toString)
+    .and[SampleReturnChange](EventType.SAMPLE_RETURN_CHANGE.toString)
     .and[ExtendedUseStatusChange](EventType.EXTENDED_USE_STATUS_CHANGE.toString)
     .and[AssignmentChange](EventType.ASSIGNMENT_CHANGE.toString)
     .and[QueueChange](EventType.QUEUE_CHANGE.toString)

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -76,6 +76,7 @@ object MongoFormatters {
   implicit val formatAppeal: OFormat[Appeal] = Json.format[Appeal]
   implicit val formatCancellation: OFormat[Cancellation] = Json.format[Cancellation]
   implicit val formatDecision: OFormat[Decision] = Json.format[Decision]
+  implicit val formatSample: OFormat[Sample] = Json.format[Sample]
   implicit val formatCase: OFormat[Case] = JsonUtil.convertToOFormat(Jsonx.formatCaseClass[Case])
 
   // `Event` formatters

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -54,6 +54,7 @@ object MongoFormatters {
   implicit val formatAppealStatus: Format[AppealStatus.Value] = EnumJson.format(AppealStatus)
   implicit val formatAppealType: Format[AppealType.Value] = EnumJson.format(AppealType)
   implicit val formatSampleStatus: Format[SampleStatus.Value] = EnumJson.format(SampleStatus)
+  implicit val formatSampleReturn: Format[SampleReturn.Value] = EnumJson.format(SampleReturn)
   implicit val formatCancelReason: Format[CancelReason.Value] = EnumJson.format(CancelReason)
   implicit val formatReferralReason: Format[ReferralReason.Value] = EnumJson.format(ReferralReason)
   implicit val formatApplicationType: Format[ApplicationType.Value] = EnumJson.format(ApplicationType)

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/NewCaseRequest.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/NewCaseRequest.scala
@@ -25,7 +25,7 @@ case class NewCaseRequest
   def toCase(reference: String) = Case(
     reference = reference,
     status = CaseStatus.NEW,
-    sample = if (application.asBTI.sampleToBeProvided) Some(new Sample) else None,
+    sample = if (application.asBTI.sampleToBeProvided) Sample(status = Some(SampleStatus.AWAITING)) else Sample(),
     application = application,
     attachments = attachments
   )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
@@ -67,6 +67,7 @@ object RESTFormatters {
   implicit val formatAppealStatusChange: OFormat[AppealStatusChange] = Json.format[AppealStatusChange]
   implicit val formatAppealAdded: OFormat[AppealAdded] = Json.format[AppealAdded]
   implicit val formatSampleStatusChange: OFormat[SampleStatusChange] = Json.format[SampleStatusChange]
+  implicit val formatSampleReturnChange: OFormat[SampleReturnChange] = Json.format[SampleReturnChange]
   implicit val formatExtendedUseStatusChange: OFormat[ExtendedUseStatusChange] = Json.format[ExtendedUseStatusChange]
   implicit val formatAssignmentChange: OFormat[AssignmentChange] = Json.format[AssignmentChange]
   implicit val formatQueueChange: OFormat[QueueChange] = Json.format[QueueChange]
@@ -81,6 +82,7 @@ object RESTFormatters {
     .and[AppealStatusChange](EventType.APPEAL_STATUS_CHANGE.toString)
     .and[AppealAdded](EventType.APPEAL_ADDED.toString)
     .and[SampleStatusChange](EventType.SAMPLE_STATUS_CHANGE.toString)
+    .and[SampleReturnChange](EventType.SAMPLE_RETURN_CHANGE.toString)
     .and[ExtendedUseStatusChange](EventType.EXTENDED_USE_STATUS_CHANGE.toString)
     .and[AssignmentChange](EventType.ASSIGNMENT_CHANGE.toString)
     .and[QueueChange](EventType.QUEUE_CHANGE.toString)

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
@@ -54,6 +54,7 @@ object RESTFormatters {
   implicit val formatAppeal: OFormat[Appeal] = Json.format[Appeal]
   implicit val formatCancellation: OFormat[Cancellation] = Json.format[Cancellation]
   implicit val formatDecision: OFormat[Decision] = Json.format[Decision]
+  implicit val formatSample: OFormat[Sample] = Json.format[Sample]
 
   implicit val formatCase: InvariantFormat[Case] = Jsonx.formatCaseClass[Case]
   implicit val formatNewCase: OFormat[NewCaseRequest] = Json.format[NewCaseRequest]

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
@@ -31,6 +31,7 @@ object RESTFormatters {
   implicit val formatAppealStatus: Format[AppealStatus.Value] = EnumJson.format(AppealStatus)
   implicit val formatAppealType: Format[AppealType.Value] = EnumJson.format(AppealType)
   implicit val formatSampleStatus: Format[SampleStatus.Value] = EnumJson.format(SampleStatus)
+  implicit val formatSampleReturn: Format[SampleReturn.Value] = EnumJson.format(SampleReturn)
   implicit val formatCancelReason: Format[CancelReason.Value] = EnumJson.format(CancelReason)
   implicit val formatReferralReason: Format[ReferralReason.Value] = EnumJson.format(ReferralReason)
 

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Sample.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Sample.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.bindingtariffclassification.model.SampleStatus.SampleStatus
 
 case class Sample
 (
-  status: SampleStatus = SampleStatus.AWAITING,
+  status: Option[SampleStatus] = None,
   requestedBy: Option[Operator] = None,
   returnStatus: Option[SampleReturn] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Sample.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Sample.scala
@@ -16,18 +16,14 @@
 
 package uk.gov.hmrc.bindingtariffclassification.model
 
-case class NewCaseRequest
+import uk.gov.hmrc.bindingtariffclassification.model.SampleReturn.SampleReturn
+import uk.gov.hmrc.bindingtariffclassification.model.SampleStatus.SampleStatus
+
+case class Sample
 (
-  application: Application,
-  attachments: Seq[Attachment] = Seq.empty
-) {
+  status: SampleStatus = SampleStatus.AWAITING,
+  requestedBy: Option[Operator] = None,
+  returnStatus: Option[SampleReturn] = None
+)
 
-  def toCase(reference: String) = Case(
-    reference = reference,
-    status = CaseStatus.NEW,
-    sample = if (application.asBTI.sampleToBeProvided) Some(new Sample) else None,
-    application = application,
-    attachments = attachments
-  )
 
-}

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/SampleReturn.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/SampleReturn.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffclassification.model
+
+object SampleReturn extends Enumeration {
+  type SampleReturn = Value
+
+  val YES, NO, TO_BE_CONFIRMED = Value
+}

--- a/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
@@ -38,8 +38,8 @@ class CaseService @Inject()(appConfig: AppConfig,
   }
 
   def addInitialSampleStatusIfExists(c: Case): Future[Unit] = {
-    if (c.sample.nonEmpty) {
-      val details = SampleStatusChange(None, c.sample.map(_.status), None)
+    if (c.sample.status.nonEmpty) {
+      val details = SampleStatusChange(None, c.sample.status, None)
       eventService.insert(Event(UUID.randomUUID().toString, details, Operator("-1",Some(c.application.contact.name)), c.reference, Instant.now()))
     }
     Future.successful((): Unit)

--- a/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
@@ -38,8 +38,8 @@ class CaseService @Inject()(appConfig: AppConfig,
   }
 
   def addInitialSampleStatusIfExists(c: Case): Future[Unit] = {
-    if (c.sampleStatus.nonEmpty) {
-      val details = SampleStatusChange(None, c.sampleStatus, None)
+    if (c.sample.nonEmpty) {
+      val details = SampleStatusChange(None, c.sample.map(_.status), None)
       eventService.insert(Event(UUID.randomUUID().toString, details, Operator("-1",Some(c.application.contact.name)), c.reference, Instant.now()))
     }
     Future.successful((): Unit)

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/model/CaseRequestSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/model/CaseRequestSpec.scala
@@ -43,13 +43,13 @@ class CaseRequestSpec extends UnitSpec with MockitoSugar {
       c.decision shouldBe None
       c.application shouldBe application
       c.attachments shouldBe attachments
-      c.sample shouldBe None
+      c.sample.status shouldBe None
     }
 
     "Convert NewCaseRequest To A Case with sample provided" in {
       when(application.asBTI).thenReturn(CaseData.createBTIApplicationWithAllFields)
       val c = NewCaseRequest(application, attachments).toCase("reference")
-      c.sample shouldBe Some(Sample(status = SampleStatus.AWAITING))
+      c.sample.status shouldBe Some(SampleStatus.AWAITING)
     }
   }
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/model/CaseRequestSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/model/CaseRequestSpec.scala
@@ -43,13 +43,13 @@ class CaseRequestSpec extends UnitSpec with MockitoSugar {
       c.decision shouldBe None
       c.application shouldBe application
       c.attachments shouldBe attachments
-      c.sampleStatus shouldBe None
+      c.sample shouldBe None
     }
 
     "Convert NewCaseRequest To A Case with sample provided" in {
       when(application.asBTI).thenReturn(CaseData.createBTIApplicationWithAllFields)
       val c = NewCaseRequest(application, attachments).toCase("reference")
-      c.sampleStatus shouldBe Some(SampleStatus.AWAITING)
+      c.sample shouldBe Some(Sample(status = SampleStatus.AWAITING))
     }
   }
 


### PR DESCRIPTION
Alternate proposal.   Optional enum to indicate whether a HMRC requested sample should be returned or not.    The absence of this field indicates a sample was not requested. 