### PR TITLE
Dit 2137 - changes to data model to support migrated days elapsed

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -34,5 +34,7 @@ case class Case
   decision: Option[Decision] = None,
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
-  sample: Sample = Sample()
+  sample: Sample = Sample(),
+  dateOfMigration: Option[Instant] = None,
+  migratedDaysElapsed: Option[Long] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Case.scala
@@ -35,6 +35,6 @@ case class Case
   attachments: Seq[Attachment] = Seq.empty,
   keywords: Set[String] = Set.empty,
   sample: Sample = Sample(),
-  dateOfMigration: Option[Instant] = None,
+  dateOfExtract: Option[Instant] = None,
   migratedDaysElapsed: Option[Long] = None
 )

--- a/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.bindingtariffclassification.repository.{CaseRepository, Seque
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.Success
 
 @Singleton
 class CaseService @Inject()(

--- a/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/service/CaseService.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.bindingtariffclassification.repository.{CaseRepository, Seque
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.util.Success
 
 @Singleton
 class CaseService @Inject()(


### PR DESCRIPTION
This adds the migratedDaysElapsed and dateOfExtraction fields to the back end.