### PR TITLE
DIT-2270 | Added CaseCreated event type

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
@@ -98,6 +98,15 @@ case class CompletedCaseStatusChange
   override val `type`: EventType.Value = EventType.CASE_COMPLETED
 }
 
+case class CaseCreated
+(
+  operator: Operator,
+  comment: String,
+  dateOfCreation: String
+) extends Details {
+  override val `type`: EventType = EventType.CASE_CREATED
+}
+
 case class AppealAdded
 (
   appealType: AppealType,
@@ -184,4 +193,5 @@ object EventType extends Enumeration {
   val NOTE = Value
   val SAMPLE_STATUS_CHANGE = Value
   val SAMPLE_RETURN_CHANGE = Value
+  val CASE_CREATED = Value
 }

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Event.scala
@@ -100,9 +100,7 @@ case class CompletedCaseStatusChange
 
 case class CaseCreated
 (
-  operator: Operator,
-  comment: String,
-  dateOfCreation: String
+  comment: String
 ) extends Details {
   override val `type`: EventType = EventType.CASE_CREATED
 }

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -93,6 +93,7 @@ object MongoFormatters {
   implicit val formatAssignmentChange: OFormat[AssignmentChange] = Json.format[AssignmentChange]
   implicit val formatQueueChange: OFormat[QueueChange] = Json.format[QueueChange]
   implicit val formatNote: OFormat[Note] = Json.format[Note]
+  implicit val formatCaseCreated: OFormat[CaseCreated] = Json.format[CaseCreated]
 
   implicit val formatEventDetail: Format[Details] = Union.from[Details]("type")
     .and[CaseStatusChange](EventType.CASE_STATUS_CHANGE.toString)
@@ -107,6 +108,7 @@ object MongoFormatters {
     .and[AssignmentChange](EventType.ASSIGNMENT_CHANGE.toString)
     .and[QueueChange](EventType.QUEUE_CHANGE.toString)
     .and[Note](EventType.NOTE.toString)
+    .and[CaseCreated](EventType.CASE_CREATED.toString)
     .format
 
 

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
@@ -87,6 +87,7 @@ object RESTFormatters {
   implicit val formatExtendedUseStatusChange: OFormat[ExtendedUseStatusChange] = Json.format[ExtendedUseStatusChange]
   implicit val formatAssignmentChange: OFormat[AssignmentChange] = Json.format[AssignmentChange]
   implicit val formatQueueChange: OFormat[QueueChange] = Json.format[QueueChange]
+  implicit val formatCaseCreated: OFormat[CaseCreated] = Json.format[CaseCreated]
 
   implicit val formatNote: OFormat[Note] = Json.format[Note]
 
@@ -103,6 +104,7 @@ object RESTFormatters {
     .and[AssignmentChange](EventType.ASSIGNMENT_CHANGE.toString)
     .and[QueueChange](EventType.QUEUE_CHANGE.toString)
     .and[Note](EventType.NOTE.toString)
+    .and[CaseCreated](EventType.CASE_CREATED.toString)
     .format
 
 

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
@@ -215,8 +215,8 @@ class EventSpec extends BaseFeatureSpec {
       val responseEvent = Json.parse(result.body).as[Event]
       responseEvent.caseReference shouldBe caseRef
 
-      val x = responseEvent.details.asInstanceOf[CaseCreated]
-      x.comment shouldBe "Liability case created"
+      val caseCreatedEvent = responseEvent.details.asInstanceOf[CaseCreated]
+      caseCreatedEvent.comment shouldBe "Liability case created"
     }
   }
 

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
@@ -38,7 +38,6 @@ class EventSpec extends BaseFeatureSpec {
   private val e1 = createCaseStatusChangeEvent(caseReference = caseRef)
   private val e2 = createNoteEvent(caseReference = caseRef)
 
-
   feature("Delete All") {
 
     scenario("Clear Collection") {
@@ -194,6 +193,28 @@ class EventSpec extends BaseFeatureSpec {
       responseEvent.caseReference shouldBe caseRef
     }
 
+  }
+
+  feature("Add a case created event") {
+
+    scenario("Create new event") {
+      Given("A case that will get created")
+      storeCases(c1)
+
+      When("I create an Event")
+      val payload = NewEventRequest(CaseCreated("Case created"), Operator("user-id", Some("user name")))
+      val result = Http(s"$serviceUrl/cases/$caseRef/events")
+        .header(apiTokenKey, appConfig.authorization)
+        .header(CONTENT_TYPE, ContentTypes.JSON)
+        .postData(Json.toJson(payload).toString()).asString
+
+      Then("The response code should be CREATED")
+      result.code shouldEqual Status.CREATED
+
+      And("The event is returned in the JSON response")
+      val responseEvent = Json.parse(result.body).as[Event]
+      responseEvent.caseReference shouldBe caseRef
+    }
   }
 
 }

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/EventSpec.scala
@@ -202,7 +202,7 @@ class EventSpec extends BaseFeatureSpec {
       storeCases(c1)
 
       When("I create an Event")
-      val payload = NewEventRequest(CaseCreated("Case created"), Operator("user-id", Some("user name")))
+      val payload = NewEventRequest(CaseCreated("Liability case created"), Operator("user-id", Some("user name")))
       val result = Http(s"$serviceUrl/cases/$caseRef/events")
         .header(apiTokenKey, appConfig.authorization)
         .header(CONTENT_TYPE, ContentTypes.JSON)
@@ -214,6 +214,9 @@ class EventSpec extends BaseFeatureSpec {
       And("The event is returned in the JSON response")
       val responseEvent = Json.parse(result.body).as[Event]
       responseEvent.caseReference shouldBe caseRef
+
+      val x = responseEvent.details.asInstanceOf[CaseCreated]
+      x.comment shouldBe "Liability case created"
     }
   }
 

--- a/test/util/EventData.scala
+++ b/test/util/EventData.scala
@@ -46,7 +46,7 @@ object EventData {
   def createCaseCreatedEvent(caseReference: String, date: Instant = Instant.now()): Event = {
     createEvent(
       caseRef = caseReference,
-      details = CaseCreated("Case created"),
+      details = CaseCreated("Liability case created"),
       date = date
     )
   }

--- a/test/util/EventData.scala
+++ b/test/util/EventData.scala
@@ -43,14 +43,6 @@ object EventData {
     )
   }
 
-  def createCaseCreatedEvent(caseReference: String, date: Instant = Instant.now()): Event = {
-    createEvent(
-      caseRef = caseReference,
-      details = CaseCreated("Liability case created"),
-      date = date
-    )
-  }
-
   def createCaseStatusChangeEvent(caseReference: String, from: CaseStatus = DRAFT, to : CaseStatus = NEW, date: Instant = Instant.now()): Event = {
     createEvent(
       caseRef = caseReference,

--- a/test/util/EventData.scala
+++ b/test/util/EventData.scala
@@ -43,6 +43,14 @@ object EventData {
     )
   }
 
+  def createCaseCreatedEvent(caseReference: String, date: Instant = Instant.now()): Event = {
+    createEvent(
+      caseRef = caseReference,
+      details = CaseCreated("Case created"),
+      date = date
+    )
+  }
+
   def createCaseStatusChangeEvent(caseReference: String, from: CaseStatus = DRAFT, to : CaseStatus = NEW, date: Instant = Instant.now()): Event = {
     createEvent(
       caseRef = caseReference,


### PR DESCRIPTION
This PR should be merged before https://github.com/hmrc/tariff-classification-frontend/pull/379 and https://github.com/hmrc/binding-tariff-trader-frontend/pull/190

It PR introduces the Case_Created event functionality.