### PR TITLE
DIT-2264 | Removed importOrExport model

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/model/Application.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/Application.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 
 import uk.gov.hmrc.bindingtariffclassification.model
 import uk.gov.hmrc.bindingtariffclassification.model.ApplicationType.ApplicationType
-import uk.gov.hmrc.bindingtariffclassification.model.ImportExport.ImportExport
 import uk.gov.hmrc.bindingtariffclassification.model.LiabilityStatus.LiabilityStatus
 
 sealed trait Application {
@@ -42,7 +41,6 @@ case class BTIApplication
   goodName: String,
   goodDescription: String,
   confidentialInformation: Option[String] = None,
-  importOrExport: Option[ImportExport] = None,
   otherInformation: Option[String] = None,
   reissuedBTIReference: Option[String] = None,
   relatedBTIReference: Option[String] = None,
@@ -104,9 +102,4 @@ object LiabilityStatus extends Enumeration {
 object ApplicationType extends Enumeration {
   type ApplicationType = Value
   val BTI, LIABILITY_ORDER = Value
-}
-
-object ImportExport extends Enumeration {
-  type ImportExport = Value
-  val IMPORT, EXPORT = Value
 }

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -65,8 +65,6 @@ object MongoFormatters {
   implicit val formatAgentDetails: OFormat[AgentDetails] = Json.format[AgentDetails]
   implicit val formatContact: OFormat[Contact] = Json.format[Contact]
 
-  implicit val formatImportExport: Format[ImportExport.Value] = EnumJson.format(ImportExport)
-
   implicit val formatLiabilityOrder: OFormat[LiabilityOrder] = Json.format[LiabilityOrder]
   implicit val formatBTIApplication: OFormat[BTIApplication] = Json.format[BTIApplication]
   implicit val formatApplication: Format[Application] = Union.from[Application]("type")

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/RESTFormatters.scala
@@ -52,7 +52,6 @@ object RESTFormatters {
   }
 
   implicit val formatReportResult: OFormat[ReportResult] = Json.format[ReportResult]
-  implicit val formatImportExport: Format[ImportExport.Value] = EnumJson.format(ImportExport)
 
   implicit val formatOperator: OFormat[Operator] = Json.format[Operator]
   implicit val formatEORIDetails: OFormat[EORIDetails] = Json.format[EORIDetails]

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/CaseSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/CaseSpec.scala
@@ -25,7 +25,6 @@ import play.api.http.HttpVerbs
 import play.api.http.Status._
 import play.api.libs.json.Json
 import scalaj.http.{Http, HttpResponse}
-import uk.gov.hmrc.bindingtariffclassification.model.ImportExport.EXPORT
 import uk.gov.hmrc.bindingtariffclassification.model.RESTFormatters._
 import uk.gov.hmrc.bindingtariffclassification.model._
 import util.CaseData._
@@ -62,10 +61,10 @@ class CaseSpec extends BaseFeatureSpec {
   private val c9 = createCase(decision = Some(createDecision(justification = "this LLLLaptoppp")))
   private val c10 = createCase(keywords = Set("MTB", "BICYCLE"))
   private val c11 = createCase(decision = Some(createDecision(
-      goodsDescription = "LAPTOP",
-      effectiveStartDate = Some(Instant.now().minus(3, ChronoUnit.DAYS)),
-      effectiveEndDate = Some(Instant.now().minus(1, ChronoUnit.DAYS)))
-    ),
+    goodsDescription = "LAPTOP",
+    effectiveStartDate = Some(Instant.now().minus(3, ChronoUnit.DAYS)),
+    effectiveEndDate = Some(Instant.now().minus(1, ChronoUnit.DAYS)))
+  ),
     status = CaseStatus.COMPLETED)
   private val c12 = createCase(decision = Some(createDecision(
     goodsDescription = "SPANNER",
@@ -130,7 +129,6 @@ class CaseSpec extends BaseFeatureSpec {
       val responseCase = Json.parse(result.body).as[Case]
       responseCase.reference shouldBe "504400001"
       responseCase.status shouldBe CaseStatus.NEW
-      responseCase.application.asBTI.importOrExport shouldBe None
     }
 
     scenario("Extra fields are ignored when creating a case") {
@@ -168,7 +166,6 @@ class CaseSpec extends BaseFeatureSpec {
       val responseCase = Json.parse(result.body).as[Case]
       responseCase.reference shouldBe "504400001"
       responseCase.status shouldBe CaseStatus.NEW
-      responseCase.application.asBTI.importOrExport shouldBe Some(EXPORT)
     }
 
     scenario("Create a new liability case with new fields DIT-1962") {

--- a/test/util/CaseData.scala
+++ b/test/util/CaseData.scala
@@ -47,7 +47,6 @@ object CaseData {
       goodDescription = "this is a BTI application for HTC Wildfire mobile phones",
       goodName = "HTC Wildfire smartphone",
       confidentialInformation = Some("This phone has a secret processor."),
-      importOrExport = Some(ImportExport.EXPORT),
       otherInformation = Some("The phone comes in multiple colors"),
       reissuedBTIReference = Some("BTI123"),
       relatedBTIReference = Some("BTI987"),


### PR DESCRIPTION
This PR removes the import/export field from the model. It should be merged first before https://github.com/hmrc/tariff-classification-frontend/pull/381 and https://github.com/hmrc/binding-tariff-trader-frontend/pull/192