### PR TITLE
DIT-2360 Add case status sort

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/repository/SearchMapper.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/repository/SearchMapper.scala
@@ -182,6 +182,7 @@ class SearchMapper @Inject()(appConfig: AppConfig) {
       case APPLICATION_STATUS => "application.status"
       case APPLICATION_TYPE => "application.type"
       case GOODS_NAME => "application.goodName"
+      case STATUS => "status"
       case s => throw new IllegalArgumentException(s"cannot sort by field: $s")
     }
   }

--- a/app/uk/gov/hmrc/bindingtariffclassification/sort/CaseSortField.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/sort/CaseSortField.scala
@@ -28,4 +28,5 @@ object CaseSortField extends Enumeration {
   val APPLICATION_STATUS = Value("application.status")
   val APPLICATION_TYPE = Value("application.type")
   val GOODS_NAME = Value("application.goodName")
+  val STATUS = Value("status")
 }

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseSearchMapperSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseSearchMapperSpec.scala
@@ -287,6 +287,26 @@ class CaseSearchMapperSpec extends BaseMongoIndexSpec {
 
       jsonMapper.sortBy(sort) shouldBe Json.obj("application.goodName" -> 1)
     }
+
+    "sort by case status and set direction ascending" in {
+
+      val sort = CaseSort(
+        field = Set(CaseSortField.STATUS),
+        direction = SortDirection.ASCENDING
+      )
+
+      jsonMapper.sortBy(sort) shouldBe Json.obj("status" -> 1)
+    }
+
+    "sort by case status and set direction descending" in {
+
+      val sort = CaseSort(
+        field = Set(CaseSortField.STATUS),
+        direction = SortDirection.DESCENDING
+      )
+
+      jsonMapper.sortBy(sort) shouldBe Json.obj("status" -> -1)
+    }
   }
 
   "fromReference()" should {


### PR DESCRIPTION
This is needed in order to sort by case status on the Applications and Rulings dashboard in the application service
Must be merged before https://github.com/hmrc/binding-tariff-trader-frontend/pull/259