### PR TITLE
DIT-2727 Rewrite job scheduler to use cron expressions

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.bindingtariffclassification.config
 
-import java.time.{Clock, LocalTime}
-
+import java.time.Clock
 import javax.inject._
-import play.api.{Configuration, Logger}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import cron4s.Cron
+import cron4s.expr.CronExpr
+import play.api.{Configuration, Logger}
 import scala.concurrent.duration._
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
 class AppConfig @Inject() (
@@ -46,20 +46,17 @@ class AppConfig @Inject() (
 
   lazy val activeDaysElapsed: JobConfig = JobConfig(
     getBooleanConfig("scheduler.active-days-elapsed.enabled"),
-    LocalTime.parse(configuration.get[String]("scheduler.active-days-elapsed.run-time")),
-    getDuration("scheduler.active-days-elapsed.interval").asInstanceOf[FiniteDuration]
+    Cron.unsafeParse(configuration.get[String]("scheduler.active-days-elapsed.schedule"))
   )
 
   lazy val referredDaysElapsed: JobConfig = JobConfig(
     getBooleanConfig("scheduler.referred-days-elapsed.enabled"),
-    LocalTime.parse(configuration.get[String]("scheduler.referred-days-elapsed.run-time")),
-    getDuration("scheduler.referred-days-elapsed.interval").asInstanceOf[FiniteDuration]
+    Cron.unsafeParse(configuration.get[String]("scheduler.referred-days-elapsed.schedule"))
   )
 
   lazy val fileStoreCleanup: JobConfig = JobConfig(
     getBooleanConfig("scheduler.filestore-cleanup.enabled"),
-    LocalTime.parse(configuration.get[String]("scheduler.filestore-cleanup.run-time")),
-    getDuration("scheduler.filestore-cleanup.interval").asInstanceOf[FiniteDuration]
+    Cron.unsafeParse(configuration.get[String]("scheduler.filestore-cleanup.schedule"))
   )
 
   lazy val authorization: String = configuration.get[String]("auth.api-token")
@@ -95,6 +92,4 @@ class AppConfig @Inject() (
 
 case class MongoEncryption(enabled: Boolean = false, key: Option[String] = None)
 
-case class JobConfig(enabled: Boolean, elapseTime: LocalTime, interval: FiniteDuration) {
-  require(interval >= 1.days, "Scheduled job interval must be greater than or equal to 1 day")
-}
+case class JobConfig(enabled: Boolean, schedule: CronExpr)

--- a/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/config/AppConfig.scala
@@ -22,6 +22,7 @@ import javax.inject._
 import play.api.{Configuration, Logger}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import scala.concurrent.duration._
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 @Singleton
@@ -93,4 +94,7 @@ class AppConfig @Inject() (
 }
 
 case class MongoEncryption(enabled: Boolean = false, key: Option[String] = None)
-case class JobConfig(enabled: Boolean, elapseTime: LocalTime, interval: FiniteDuration)
+
+case class JobConfig(enabled: Boolean, elapseTime: LocalTime, interval: FiniteDuration) {
+  require(interval >= 1.days, "Scheduled job interval must be greater than or equal to 1 day")
+}

--- a/app/uk/gov/hmrc/bindingtariffclassification/metrics/HasMetrics.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/metrics/HasMetrics.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffclassification.metrics
+
+import com.codahale.metrics.{MetricRegistry, Timer}
+import com.kenshoo.play.metrics.Metrics
+import java.util.concurrent.atomic.AtomicBoolean
+import play.api.mvc.{Action, BaseController, Result}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+trait HasActionMetrics extends HasMetrics { self: BaseController =>
+  /**
+    * Execute a [[play.api.mvc.Action]] with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param action The action to wrap with metrics collection
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return an action which captures metrics about the wrapped action
+    */
+  def withMetricsTimerAction[A](metric: Metric)(action: Action[A])(implicit ec: ExecutionContext): Action[A] =
+    Action(action.parser).async(request => withMetricsTimerResult(metric)(action(request)))
+}
+
+trait HasMetrics {
+  type Metric = String
+
+  def metrics: Metrics
+
+  lazy val registry: MetricRegistry = metrics.defaultRegistry
+
+  val localMetrics = new LocalMetrics
+
+  class LocalMetrics {
+    def startTimer(metric: Metric)                    = registry.timer(s"$metric-timer").time()
+    def stopTimer(context: Timer.Context)             = context.stop()
+    def incrementSuccessCounter(metric: Metric): Unit = registry.counter(s"$metric-success-counter").inc()
+    def incrementFailedCounter(metric: Metric): Unit  = registry.counter(s"$metric-failed-counter").inc()
+  }
+
+  class MetricsTimer(metric: Metric) {
+    val timer        = localMetrics.startTimer(metric)
+    val timerRunning = new AtomicBoolean(true)
+
+    def completeWithSuccess(): Unit =
+      if (timerRunning.compareAndSet(true, false)) {
+        localMetrics.stopTimer(timer)
+        localMetrics.incrementSuccessCounter(metric)
+      }
+
+    def completeWithFailure(): Unit =
+      if (timerRunning.compareAndSet(true, false)) {
+        localMetrics.stopTimer(timer)
+        localMetrics.incrementFailedCounter(metric)
+      }
+  }
+
+  /**
+    * Execute a block of code with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerResult(metric: Metric)(block: => Future[Result])(implicit ec: ExecutionContext): Future[Result] =
+    withMetricsTimer(metric) { timer =>
+      try {
+        val result = block
+
+        // Clean up timer according to server response
+        result.foreach { result =>
+          if (isFailureStatus(result.header.status))
+            timer.completeWithFailure()
+          else
+            timer.completeWithSuccess()
+        }
+
+        // Clean up timer for unhandled exceptions
+        result.failed.foreach(_ => timer.completeWithFailure())
+
+        result
+
+      } catch {
+        case NonFatal(e) =>
+          timer.completeWithFailure()
+          throw e
+      }
+    }
+
+  /**
+    * Execute a block of code with a metrics timer.
+    *
+    * Intended for use in connectors that call other microservices.
+    *
+    * It's expected that the user of this method might want to handle
+    * connector failures gracefully and therefore they are given a [[MetricsTimer]]
+    * to optionally record whether the call was a success or a failure.
+    *
+    * If the user does not specify otherwise the status of the result Future is
+    * used to determine whether the block was successful or not.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerAsync[T](
+    metric: Metric
+  )(block: MetricsTimer => Future[T])(implicit ec: ExecutionContext): Future[T] =
+    withMetricsTimer(metric) { timer =>
+      try {
+        val result = block(timer)
+
+        // Clean up timer if the user doesn't
+        result.foreach(_ => timer.completeWithSuccess())
+
+        // Clean up timer on unhandled exceptions
+        result.failed.foreach(_ => timer.completeWithFailure())
+
+        result
+
+      } catch {
+        case NonFatal(e) =>
+          timer.completeWithFailure()
+          throw e
+      }
+    }
+
+  private def withMetricsTimer[T](metric: Metric)(block: MetricsTimer => T): T =
+    block(new MetricsTimer(metric))
+
+  private def isFailureStatus(status: Int) =
+    status / 100 >= 4
+}

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/JobRunEvent.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/JobRunEvent.scala
@@ -16,6 +16,6 @@
 
 package uk.gov.hmrc.bindingtariffclassification.model
 
-import java.time.Instant
+import java.time.ZonedDateTime
 
-case class JobRunEvent(name: String, runDate: Instant)
+case class JobRunEvent(name: String, runDate: ZonedDateTime)

--- a/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/model/MongoFormatters.scala
@@ -21,6 +21,8 @@ import java.time.Instant
 import play.api.libs.json._
 import uk.gov.hmrc.bindingtariffclassification.utils.JsonUtil
 import uk.gov.hmrc.play.json.Union
+import java.time.ZonedDateTime
+import java.time.ZoneOffset
 
 object MongoFormatters {
   implicit val formatInstant: OFormat[Instant] = new OFormat[Instant] {
@@ -37,6 +39,12 @@ object MongoFormatters {
         case _ => JsError("Unexpected Instant Format")
       }
   }
+
+  implicit val formatZonedDateTime: OFormat[ZonedDateTime] =
+    formatInstant.bimap(
+      instant => ZonedDateTime.ofInstant(instant, ZoneOffset.UTC),
+      datetime => datetime.toInstant
+    )
 
   // `Sequence` formatters
   implicit val formatSequence: OFormat[Sequence] = Json.format[Sequence]

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/Scheduler.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/Scheduler.scala
@@ -85,10 +85,7 @@ class Scheduler @Inject() (
 
   private def durationUntil(datetime: Instant): FiniteDuration = {
     val now = Instant.now(appConfig.clock)
-
-    if (datetime.isBefore(now))
-      throw new IllegalArgumentException(s"Expected a future or present datetime but was [$datetime]")
-    else FiniteDuration(now.until(datetime, ChronoUnit.SECONDS), TimeUnit.SECONDS)
+    val seconds = Math.max(0L, now.until(datetime, ChronoUnit.SECONDS))
+    FiniteDuration(seconds, TimeUnit.SECONDS)
   }
-
 }

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
@@ -16,15 +16,11 @@
 
 package uk.gov.hmrc.bindingtariffclassification.scheduler
 
-import java.time.{Instant, LocalDate, LocalTime}
-
-import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
-
-import scala.concurrent.duration.FiniteDuration
-import java.time.ZonedDateTime
-import java.time.temporal.TemporalUnit
+import java.time.{Instant, LocalDate, LocalTime, ZonedDateTime}
 import java.time.temporal.ChronoUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.FiniteDuration
+import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
 
 @Singleton
 class SchedulerDateUtil @Inject() (appConfig: AppConfig) {

--- a/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerDateUtil.scala
@@ -22,50 +22,41 @@ import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
 
 import scala.concurrent.duration.FiniteDuration
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalUnit
+import java.time.temporal.ChronoUnit
 
 @Singleton
 class SchedulerDateUtil @Inject() (appConfig: AppConfig) {
 
-  private lazy val clock = appConfig.clock
-
   def nextRun(offset: LocalTime, interval: FiniteDuration): Instant = {
-    val time = LocalTime.now(clock).withNano(0)
+    val now = ZonedDateTime.now(appConfig.clock).withNano(0)
 
-    val offsetSeconds: Int  = offset.toSecondOfDay
-    val currentSeconds: Int = time.toSecondOfDay
+    val offsetToday = now.`with`(offset)
 
-    val intervalSeconds: Long   = interval.toSeconds
-    val deltaSeconds: Int       = offsetSeconds - currentSeconds
-    val intervalRemainder: Long = deltaSeconds % intervalSeconds
-
-    val intervalRemaining: Long = if (intervalRemainder < 0) intervalRemainder + intervalSeconds else intervalRemainder
-    LocalDate
-      .now(clock)
-      .atTime(time)
-      .plusSeconds(intervalRemaining)
-      .atZone(clock.getZone)
-      .toInstant
+    if (offsetToday.isBefore(now))
+      offsetToday.plus(interval.toMillis, ChronoUnit.MILLIS).toInstant
+    else
+      offsetToday.toInstant
   }
 
   def closestRun(offset: LocalTime, interval: FiniteDuration): Instant = {
-    val time = LocalTime.now(clock).withNano(0)
+    val now = ZonedDateTime.now(appConfig.clock).withNano(0)
 
-    val offsetSeconds: Int  = offset.toSecondOfDay
-    val currentSeconds: Int = time.toSecondOfDay
+    val offsetToday = now.`with`(offset)
 
-    val intervalSeconds: Long   = interval.toSeconds
-    val deltaSeconds: Int       = offsetSeconds - currentSeconds
-    val intervalRemainder: Long = deltaSeconds % intervalSeconds
+    val prevRun =
+      if (offsetToday.isBefore(now)) offsetToday else offsetToday.minus(interval.toMillis, ChronoUnit.MILLIS)
+    val nextRun =
+      if (!offsetToday.isBefore(now)) offsetToday else offsetToday.plus(interval.toMillis, ChronoUnit.MILLIS)
 
-    val intervalRemaining: Long = if (intervalRemainder < 0) intervalRemainder + intervalSeconds else intervalRemainder
-    val intervalElapsed: Long   = intervalSeconds - intervalRemaining
-    if (intervalRemaining == 0) {
-      LocalDate.now(clock).atTime(time).atZone(clock.getZone).toInstant
-    } else if (intervalRemaining < intervalElapsed) {
-      LocalDate.now(clock).atTime(time).plusSeconds(intervalRemaining).atZone(clock.getZone).toInstant
-    } else {
-      LocalDate.now(clock).atTime(time).minusSeconds(intervalElapsed).atZone(clock.getZone).toInstant
-    }
+    val timeUntilNext = ChronoUnit.MILLIS.between(now, nextRun)
+    val timeSinceLast = ChronoUnit.MILLIS.between(prevRun, now)
+
+    if (timeUntilNext <= timeSinceLast)
+      nextRun.toInstant
+    else
+      prevRun.toInstant
   }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,20 +145,20 @@ upsert-permitted-agents = "binding-tariff-admin-frontend"
 scheduler {
   active-days-elapsed {
     enabled = true
-    run-time = "03:00"
-    interval = "1d"
+    # 3am every day
+    schedule = "0 0 3 * * ?"
   }
 
   referred-days-elapsed {
     enabled = true
-    run-time = "02:00"
-    interval = "1d"
+    # 2am every day
+    schedule = "0 0 2 * * ?"
   }
 
   filestore-cleanup {
     enabled = false
-    run-time = "01:00"
-    interval = "7d"
+    # 1am every Sunday - see https://github.com/alonsodomin/cron4s/issues/95
+    schedule = "0 0 1 ? * 6"
   }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,12 +5,13 @@ import play.core.PlayVersion.current
 object AppDependencies {
 
   lazy val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-play-26"         % "1.7.0",
-    "uk.gov.hmrc"       %% "crypto"                    % "5.6.0",
-    "uk.gov.hmrc"       %% "play-json-union-formatter" % "1.11.0",
-    "uk.gov.hmrc"       %% "simple-reactivemongo"      % "7.30.0-play-26",
-    "org.reactivemongo" %% "reactivemongo-akkastream"  % "0.18.8",
-    "com.typesafe.play" %% "play-json"                 % "2.9.2",
+    "uk.gov.hmrc"                   %% "bootstrap-play-26"         % "1.7.0",
+    "uk.gov.hmrc"                   %% "crypto"                    % "5.6.0",
+    "uk.gov.hmrc"                   %% "play-json-union-formatter" % "1.11.0",
+    "uk.gov.hmrc"                   %% "simple-reactivemongo"      % "7.30.0-play-26",
+    "org.reactivemongo"             %% "reactivemongo-akkastream"  % "0.18.8",
+    "com.typesafe.play"             %% "play-json"                 % "2.9.2",
+    "com.github.alonsodomin.cron4s" %% "cron4s-core"               % "0.6.1",
     ws
   )
 

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/ActiveDaysElapsedSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/ActiveDaysElapsedSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.bindingtariffclassification.component
 
 import java.time._
 
+import com.kenshoo.play.metrics.Metrics
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -27,7 +28,7 @@ import uk.gov.hmrc.bindingtariffclassification.model.CaseStatus._
 import uk.gov.hmrc.bindingtariffclassification.model.{Case, Event}
 import uk.gov.hmrc.bindingtariffclassification.scheduler.ActiveDaysElapsedJob
 import util.CaseData._
-import util.EventData
+import util.{EventData, TestMetrics}
 
 import scala.concurrent.Await.result
 
@@ -41,6 +42,7 @@ class ActiveDaysElapsedSpec extends BaseFeatureSpec with MockitoSugar {
     .disable[com.kenshoo.play.metrics.PlayModule]
     .configure("metrics.enabled" -> false)
     .configure("mongodb.uri" -> "mongodb://localhost:27017/test-ClassificationMongoRepositoryTest")
+    .overrides(bind[Metrics].toInstance(new TestMetrics))
     .injector()
 
   private val job: ActiveDaysElapsedJob = injector.instanceOf[ActiveDaysElapsedJob]

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/BaseFeatureSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/BaseFeatureSpec.scala
@@ -16,12 +16,15 @@
 
 package uk.gov.hmrc.bindingtariffclassification.component
 
+import com.kenshoo.play.metrics.Metrics
 import org.scalatest._
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
 import uk.gov.hmrc.bindingtariffclassification.model.{Case, Event, Sequence}
 import uk.gov.hmrc.bindingtariffclassification.repository.{CaseMongoRepository, EventMongoRepository, SchedulerLockMongoRepository, SequenceMongoRepository}
+import util.TestMetrics
 
 import scala.concurrent.Await.result
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -37,6 +40,7 @@ abstract class BaseFeatureSpec
 
   override lazy val app = GuiceApplicationBuilder()
     .configure("mongodb.uri" -> "mongodb://localhost:27017/test-ClassificationMongoRepositoryTest")
+    .overrides(bind[Metrics].toInstance(new TestMetrics))
     .build()
 
   protected val timeout: FiniteDuration = 5.seconds

--- a/test/it/uk/gov/hmrc/bindingtariffclassification/component/ReferredDaysElapsedSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtariffclassification/component/ReferredDaysElapsedSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.bindingtariffclassification.component
 
 import java.time._
 
+import com.kenshoo.play.metrics.Metrics
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -27,7 +28,7 @@ import uk.gov.hmrc.bindingtariffclassification.model.CaseStatus._
 import uk.gov.hmrc.bindingtariffclassification.model.{Case, CaseStatus, Event}
 import uk.gov.hmrc.bindingtariffclassification.scheduler.ReferredDaysElapsedJob
 import util.CaseData._
-import util.EventData
+import util.{EventData, TestMetrics}
 
 import scala.concurrent.Await.result
 
@@ -41,6 +42,7 @@ class ReferredDaysElapsedSpec extends BaseFeatureSpec with MockitoSugar {
     .disable[com.kenshoo.play.metrics.PlayModule]
     .configure("metrics.enabled" -> false)
     .configure("mongodb.uri" -> "mongodb://localhost:27017/test-ClassificationMongoRepositoryTest")
+    .overrides(bind[Metrics].toInstance(new TestMetrics))
     .injector()
 
   private val job: ReferredDaysElapsedJob = injector.instanceOf[ReferredDaysElapsedJob]

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/base/BaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/base/BaseSpec.scala
@@ -17,24 +17,31 @@
 package uk.gov.hmrc.bindingtariffclassification.base
 
 import akka.stream.Materializer
+import com.kenshoo.play.metrics.Metrics
 import org.scalatest.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{BodyParsers, MessagesControllerComponents}
 import uk.gov.hmrc.bindingtariffclassification.connector.ResourceFiles
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.test.UnitSpec
+import util.TestMetrics
 
 abstract class BaseSpec extends UnitSpec with GuiceOneAppPerSuite with MockitoSugar with ResourceFiles with Matchers {
 
   override lazy val fakeApplication: Application = GuiceApplicationBuilder()
     .configure(
       "metrics.jvm"     -> false,
-      "metrics.enabled" -> false
+      "metrics.enabled" -> false,
+      "scheduler.active-days-elapsed.enabled" -> false,
+      "scheduler.referred-days-elapsed.enabled" -> false,
+      "scheduler.filestore-cleanup.enabled" -> false
     )
+    .overrides(bind[Metrics].toInstance(new TestMetrics))
     .build()
 
   implicit val mat: Materializer = fakeApplication.materializer

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/config/AppConfigTest.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.bindingtariffclassification.config
 
-import java.time.{LocalTime, ZoneOffset}
+import java.time.ZoneOffset
 
+import cron4s.Cron
 import play.api.Configuration
 import uk.gov.hmrc.bindingtariffclassification.base.BaseSpec
-
-import scala.concurrent.duration._
 
 class AppConfigTest extends BaseSpec {
 
@@ -42,34 +41,28 @@ class AppConfigTest extends BaseSpec {
     "build 'ActiveDaysElapsedConfig'" in {
       val config = configWith(
         "scheduler.active-days-elapsed.enabled"  -> "true",
-        "scheduler.active-days-elapsed.run-time" -> "00:00",
-        "scheduler.active-days-elapsed.interval" -> "1d"
+        "scheduler.active-days-elapsed.schedule" -> "0 0 3 * * ?"
       ).activeDaysElapsed
       config.enabled    shouldBe true
-      config.elapseTime shouldBe LocalTime.of(0, 0, 0)
-      config.interval   shouldBe 1.days
+      config.schedule   shouldBe Cron.unsafeParse("0 0 3 * * ?")
     }
 
     "build 'ReferredDaysElapsedConfig'" in {
       val config = configWith(
         "scheduler.referred-days-elapsed.enabled"  -> "true",
-        "scheduler.referred-days-elapsed.run-time" -> "00:00",
-        "scheduler.referred-days-elapsed.interval" -> "1d"
+        "scheduler.referred-days-elapsed.schedule" -> "0 0 2 * * ?"
       ).referredDaysElapsed
       config.enabled    shouldBe true
-      config.elapseTime shouldBe LocalTime.of(0, 0, 0)
-      config.interval   shouldBe 1.days
+      config.schedule   shouldBe Cron.unsafeParse("0 0 2 * * ?")
     }
 
     "build 'fileStoreCleanupConfig'" in {
       val config = configWith(
         "scheduler.filestore-cleanup.enabled"  -> "true",
-        "scheduler.filestore-cleanup.run-time" -> "03:00",
-        "scheduler.filestore-cleanup.interval" -> "7d"
+        "scheduler.filestore-cleanup.schedule" -> "0 0 1 ? * 0"
       ).fileStoreCleanup
       config.enabled    shouldBe true
-      config.elapseTime shouldBe LocalTime.of(3, 0, 0)
-      config.interval   shouldBe 7.days
+      config.schedule   shouldBe Cron.unsafeParse("0 0 1 ? * 0")
     }
 
     "build 'fileStoreUrl'" in {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/connector/BankHolidaysConnectorTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/connector/BankHolidaysConnectorTest.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.bindingtariffclassification.config.AppConfig
 import uk.gov.hmrc.bindingtariffclassification.http.ProxyHttpClient
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.HttpAuditing
+import util.TestMetrics
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -43,7 +44,7 @@ class BankHolidaysConnectorTest extends BaseSpec with WiremockTestServer with Be
   private val httpAuditEvent      = fakeApplication.injector.instanceOf[HttpAuditing]
   private val hmrcProxyHttpClient = new ProxyHttpClient(fakeApplication.configuration, httpAuditEvent, wsClient)
 
-  private val connector = new BankHolidaysConnector(config, hmrcProxyHttpClient)
+  private val connector = new BankHolidaysConnector(config, hmrcProxyHttpClient, new TestMetrics)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/connector/FileStoreConnectorTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/connector/FileStoreConnectorTest.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.bindingtariffclassification.model.filestore.{FileMetadata, Fi
 import uk.gov.hmrc.bindingtariffclassification.model.{Paged, Pagination}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.HttpAuditing
+import util.TestMetrics
 
 class FileStoreConnectorTest extends BaseSpec with WiremockTestServer with BeforeAndAfterAll {
 
@@ -52,7 +53,7 @@ class FileStoreConnectorTest extends BaseSpec with WiremockTestServer with Befor
     actorSystem
   )
 
-  private val connector = new FileStoreConnector(config, hmrcAuthenticatedHttpClient)
+  private val connector = new FileStoreConnector(config, hmrcAuthenticatedHttpClient, new TestMetrics)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/metrics/HasMetricsSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/metrics/HasMetricsSpec.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffclassification.metrics
+
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import org.scalatest.{AsyncWordSpecLike, BeforeAndAfterAll, Matchers, OptionValues}
+import org.scalatest.compatible.Assertion
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.{MessagesAbstractController, Results}
+import play.api.test.{FakeRequest, Helpers}
+import scala.concurrent.Future
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+
+class HasMetricsSpec
+    extends AsyncWordSpecLike
+    with Matchers
+    with OptionValues
+    with MockitoSugar
+    with BeforeAndAfterAll {
+
+  trait MockHasMetrics { self: HasMetrics =>
+    val timer                               = mock[Timer.Context]
+    val metrics                             = mock[Metrics]
+    override val localMetrics: LocalMetrics = mock[LocalMetrics]
+    when(localMetrics.startTimer(anyString())) thenReturn timer
+  }
+
+  class TestHasMetrics extends HasMetrics with MockHasMetrics
+
+  class TestHasActionMetrics
+      extends BackendController(Helpers.stubControllerComponents())
+      with HasActionMetrics
+      with MockHasMetrics
+
+  def withTestMetrics[A](test: TestHasMetrics => A): A =
+    test(new TestHasMetrics)
+
+  def withTestActionMetrics[A](test: TestHasActionMetrics => A): A =
+    test(new TestHasActionMetrics)
+
+  def verifyCompletedWithSuccess(metricName: String, metrics: MockHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).incrementSuccessCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  def verifyCompletedWithFailure(metricName: String, metrics: MockHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).incrementFailedCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  val TestMetric = "test-metric"
+
+  "HasMetrics" when {
+    "withMetricsTimerAsync" should {
+      "increment success counter for a successful future" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric)(_ => Future.successful(())).map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment success counter for a successful future where completeWithSuccess is called explicitly" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) { timer =>
+              timer.completeWithSuccess()
+              Future.successful(())
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric)(_ => Future.failed(new Exception)).recover {
+          case _ =>
+            verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a successful future where completeWithFailure is called explicitly" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) { timer =>
+              timer.completeWithFailure()
+              Future.successful(())
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with success" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) { timer =>
+              Future(timer.completeWithSuccess())
+              Future(timer.completeWithSuccess())
+              Future(timer.completeWithSuccess())
+              Future(timer.completeWithSuccess())
+              Future.successful(())
+            }
+            .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with failure" in withTestMetrics {
+        metrics =>
+          metrics
+            .withMetricsTimerAsync(TestMetric) { timer =>
+              Future(timer.completeWithFailure())
+              Future(timer.completeWithFailure())
+              Future(timer.completeWithFailure())
+              Future(timer.completeWithFailure())
+              timer.completeWithFailure()
+              Future.successful(())
+            }
+            .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter when the user throws an exception constructing their code block" in withTestMetrics {
+        metrics =>
+          assertThrows[RuntimeException] {
+            metrics.withMetricsTimerAsync(TestMetric)(_ => Future.successful(throw new RuntimeException))
+          }
+
+          Future.successful(verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+
+    "withMetricsTimerResult" should {
+      "increment success counter for a successful future of an informational Result" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.successful(Results.Continue)
+          }
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful future of a successful Result" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.successful(Results.Ok)
+          }
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful future of a redirect Result" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.successful(Results.NotModified)
+          }
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a successful future of a client error Result" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.successful(Results.EntityTooLarge)
+          }
+          .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a successful future of a server error Result" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.successful(Results.BadGateway)
+          }
+          .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics { metrics =>
+        metrics
+          .withMetricsTimerResult(TestMetric) {
+            Future.failed(new Exception)
+          }
+          .transformWith {
+            case _ =>
+              verifyCompletedWithFailure(TestMetric, metrics)
+          }
+      }
+
+      "increment failure counter when the user throws an exception constructing their code block" in withTestMetrics {
+        metrics =>
+          assertThrows[RuntimeException] {
+            metrics.withMetricsTimerResult(TestMetric) {
+              Future.successful(throw new RuntimeException)
+            }
+          }
+
+          Future.successful(verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+
+    "withMetricsTimerAction" should {
+      def fakeRequest = FakeRequest()
+
+      "increment success counter for an informational Result" in withTestActionMetrics { metrics =>
+        metrics
+          .withMetricsTimerAction(TestMetric) {
+            metrics.Action(Results.SwitchingProtocols)
+          }
+          .apply(fakeRequest)
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a successful Result" in withTestActionMetrics { metrics =>
+        metrics
+          .withMetricsTimerAction(TestMetric) {
+            metrics.Action(Results.Ok)
+          }
+          .apply(fakeRequest)
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment success counter for a redirect Result" in withTestActionMetrics { metrics =>
+        metrics
+          .withMetricsTimerAction(TestMetric) {
+            metrics.Action(Results.Found("https://wikipedia.org"))
+          }
+          .apply(fakeRequest)
+          .map(_ => verifyCompletedWithSuccess(TestMetric, metrics))
+      }
+
+      "increment failure counter for a client error Result" in withTestActionMetrics { metrics =>
+        metrics
+          .withMetricsTimerAction(TestMetric) {
+            metrics.Action(Results.Conflict)
+          }
+          .apply(fakeRequest)
+          .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+
+      "increment failure counter for a server error Result" in withTestActionMetrics { metrics =>
+        metrics
+          .withMetricsTimerAction(TestMetric) {
+            metrics.Action(Results.ServiceUnavailable)
+          }
+          .apply(fakeRequest)
+          .map(_ => verifyCompletedWithFailure(TestMetric, metrics))
+      }
+    }
+  }
+
+}

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/migrations/MigrationRunnerTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/migrations/MigrationRunnerTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.concurrent.Eventually
 import uk.gov.hmrc.bindingtariffclassification.base.BaseSpec
 import uk.gov.hmrc.bindingtariffclassification.model.JobRunEvent
 import uk.gov.hmrc.bindingtariffclassification.repository.MigrationLockRepository
+import util.TestMetrics
 
 import scala.concurrent.Future.{failed, successful}
 
@@ -95,7 +96,7 @@ class MigrationRunnerTest extends BaseSpec with BeforeAndAfterEach with Eventual
   }
 
   private def withRunner(test: MigrationRunner => Unit): Unit = {
-    val runner = new MigrationRunner(migrationRepository, MigrationJobs(Set(amendDateOfExtractJob)))
+    val runner = new MigrationRunner(migrationRepository, MigrationJobs(Set(amendDateOfExtractJob)), new TestMetrics)
     test(runner)
   }
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/MigrationLockRepositorySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/MigrationLockRepositorySpec.scala
@@ -30,6 +30,8 @@ import uk.gov.hmrc.bindingtariffclassification.model._
 import uk.gov.hmrc.mongo.MongoSpecSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.time.ZonedDateTime
+import java.time.ZoneOffset
 
 class MigrationLockRepositorySpec
     extends BaseMongoIndexSpec
@@ -68,8 +70,8 @@ class MigrationLockRepositorySpec
   private def selectorByName(name: String): BSONDocument =
     BSONDocument("name" -> name)
 
-  private def date(date: String): Instant =
-    LocalDate.parse(date).atStartOfDay(ZoneId.of("UTC")).toInstant
+  private def date(date: String): ZonedDateTime =
+    LocalDate.parse(date).atStartOfDay(ZoneOffset.UTC)
 
   private val event = JobRunEvent("name", date("2018-12-25"))
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/SchedulerLockRepositorySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/SchedulerLockRepositorySpec.scala
@@ -30,6 +30,8 @@ import uk.gov.hmrc.bindingtariffclassification.model._
 import uk.gov.hmrc.mongo.MongoSpecSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.time.ZonedDateTime
+import java.time.ZoneOffset
 
 class SchedulerLockRepositorySpec
     extends BaseMongoIndexSpec
@@ -68,8 +70,8 @@ class SchedulerLockRepositorySpec
   private def selectorByName(name: String): BSONDocument =
     BSONDocument("name" -> name)
 
-  private def date(date: String): Instant =
-    LocalDate.parse(date).atStartOfDay(ZoneId.of("UTC")).toInstant
+  private def date(date: String): ZonedDateTime =
+    LocalDate.parse(date).atStartOfDay(ZoneOffset.UTC)
 
   "lock" should {
     val event = JobRunEvent("name", date("2018-12-25"))

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/ReferredDaysElapsedJobTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/ReferredDaysElapsedJobTest.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.bindingtariffclassification.scheduler
 
 import java.time._
 
+import cron4s.Cron
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
@@ -38,12 +39,15 @@ import util.EventData.createCaseStatusChangeEventDetails
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class ReferredDaysElapsedJobTest extends BaseSpec with BeforeAndAfterEach {
 
   private val caseService           = mock[CaseService]
   private val eventService          = mock[EventService]
   private val bankHolidaysConnector = mock[BankHolidaysConnector]
+  private val fixedDate             = ZonedDateTime.of(2021, 2, 15, 12, 0, 0, 0, ZoneOffset.UTC)
+  private val clock                 = Clock.fixed(fixedDate.toInstant, ZoneOffset.UTC)
   private val appConfig             = mock[AppConfig]
   private val caseSearch = CaseSearch(
     filter = CaseFilter(statuses = Some(Set(PseudoCaseStatus.REFERRED, PseudoCaseStatus.SUSPENDED))),
@@ -55,10 +59,14 @@ class ReferredDaysElapsedJobTest extends BaseSpec with BeforeAndAfterEach {
     reset(appConfig, caseService, eventService)
   }
 
+  override protected def beforeEach(): Unit = {
+    given(appConfig.clock).willReturn(clock)
+  }
+
   "Scheduled Job" should {
 
     val runTime   = LocalTime.of(14, 0)
-    val jobConfig = JobConfig(enabled = true, elapseTime = runTime, interval = 1.day)
+    val jobConfig = JobConfig(enabled = true, schedule = Cron.unsafeParse("0 0 14 * * ?"))
 
     "Configure 'Name'" in {
       newJob.name shouldBe "ReferredDaysElapsed"
@@ -70,18 +78,11 @@ class ReferredDaysElapsedJobTest extends BaseSpec with BeforeAndAfterEach {
       newJob.enabled shouldBe true
     }
 
-    "Configure 'firstRunTime'" in {
+    "Configure 'nextRunTime'" in {
       given(appConfig.referredDaysElapsed).willReturn(jobConfig)
 
-      newJob.firstRunTime shouldBe runTime
+      newJob.nextRunTime.get shouldBe fixedDate.`with`(runTime)
     }
-
-    "Configure 'interval'" in {
-      given(appConfig.referredDaysElapsed).willReturn(jobConfig)
-
-      newJob.interval shouldBe 1.day
-    }
-
   }
 
   "Scheduled Job 'Execute'" should {

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/scheduler/SchedulerTest.scala
@@ -174,7 +174,7 @@ class SchedulerTest extends BaseSpec with BeforeAndAfterEach with Eventually {
       // Given
       givenTheLockSucceeds()
       given(job.enabled) willReturn true
-      given(job.interval) willReturn 3.seconds
+      given(job.interval) willReturn 1.day
       given(job.firstRunTime) willReturn "12:00"
       given(job.name) willReturn "name"
       given(util.nextRun(job.firstRunTime, job.interval)).willReturn("2018-12-25T11:59:59")
@@ -185,7 +185,7 @@ class SchedulerTest extends BaseSpec with BeforeAndAfterEach with Eventually {
 
       // Then
       val schedule = theSchedule
-      schedule.interval     shouldBe 3.seconds
+      schedule.interval     shouldBe 1.day
       schedule.initialDelay shouldBe 0.seconds
 
       val lockEvent = theLockEvent
@@ -197,7 +197,7 @@ class SchedulerTest extends BaseSpec with BeforeAndAfterEach with Eventually {
       // Given
       givenTheLockFails()
       given(job.enabled) willReturn true
-      given(job.interval) willReturn 1.seconds
+      given(job.interval) willReturn 1.day
       given(job.firstRunTime) willReturn now
       given(util.nextRun(job.firstRunTime, job.interval)) willReturn "2018-12-25T12:00:00"
 
@@ -211,7 +211,7 @@ class SchedulerTest extends BaseSpec with BeforeAndAfterEach with Eventually {
       // Given
       givenTheLockSucceeds()
       given(job.enabled) willReturn false
-      given(job.interval) willReturn 3.seconds
+      given(job.interval) willReturn 1.day
       given(job.firstRunTime) willReturn "12:00"
       given(job.name) willReturn "name"
       given(util.nextRun(job.firstRunTime, job.interval)) willReturn "2018-12-25T12:00:00"

--- a/test/util/TestMetrics.scala
+++ b/test/util/TestMetrics.scala
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.bindingtariffclassification.scheduler
+package util
 
-import cron4s.expr.CronExpr
-import java.time.ZonedDateTime
-import scala.concurrent.Future
+import com.kenshoo.play.metrics.Metrics
+import com.codahale.metrics.MetricRegistry
 
-trait ScheduledJob {
-  def name: String
-  def enabled: Boolean
-  def execute(): Future[Unit]
-  def schedule: CronExpr
-  def nextRunTime: Option[ZonedDateTime]
+class TestMetrics extends Metrics {
+  override def defaultRegistry: MetricRegistry = new MetricRegistry
+  override def toJson: String                  = ""
 }


### PR DESCRIPTION
This rewrites the code that schedules jobs to use cron expressions as implemented by [alonsodomin/cron4s](https://github.com/alonsodomin/cron4s).

This means that we can write scheduler config like `"0 0 3 * * ?"` to mean "at 3am every morning" or like `"0 0 1 ? * 6"` to mean "at 1am every Sunday".

The Cron expression syntax supported is similar to that of the Quartz scheduler so [this](https://www.freeformatter.com/cron-expression-generator-quartz.html) expression builder can be used to create configurations.

I have noticed that the weekday configuration is slightly different in this library and have commented about it on [this issue](https://github.com/alonsodomin/cron4s/issues/95).