### PR TITLE
DDCE-3427: Added indexes for database fields used in sorts

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffclassification/repository/CaseRepository.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/repository/CaseRepository.scala
@@ -23,7 +23,7 @@ import org.mongodb.scala.bson.{BsonDocument, BsonNull, BsonValue}
 import org.mongodb.scala.model.Accumulators.{max, sum}
 import org.mongodb.scala.model.Aggregates._
 import org.mongodb.scala.model.Filters._
-import org.mongodb.scala.model.Indexes.{ascending => asc}
+import org.mongodb.scala.model.Indexes.{ascending => asc, descending => desc}
 import org.mongodb.scala.model.Sorts.{ascending, descending, orderBy}
 import org.mongodb.scala.model._
 import org.slf4j.{Logger, LoggerFactory}
@@ -136,6 +136,7 @@ class CaseMongoRepository @Inject() (
         IndexModel(asc("assignee.id"), IndexOptions().unique(false).name("assignee.id_Index")),
         IndexModel(asc("queueId"), IndexOptions().unique(false).name("queueId_Index")),
         IndexModel(asc("status"), IndexOptions().unique(false).name("status_Index")),
+        IndexModel(desc("createdDate"), IndexOptions().unique(false).name("createdDate_Index")),
         IndexModel(
           asc("application.holder.eori"),
           IndexOptions().unique(false).name("application.holder.eori_Index")
@@ -143,6 +144,10 @@ class CaseMongoRepository @Inject() (
         IndexModel(
           asc("application.agent.eoriDetails.eori"),
           IndexOptions().unique(false).name("application.agent.eoriDetails.eori_Index")
+        ),
+        IndexModel(
+          asc("application.type"),
+          IndexOptions().unique(false).name("application.type_Index")
         ),
         IndexModel(
           asc("decision.effectiveEndDate"),

--- a/app/uk/gov/hmrc/bindingtariffclassification/repository/EventRepository.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/repository/EventRepository.scala
@@ -49,7 +49,8 @@ class EventMongoRepository @Inject() (mongoComponent: MongoComponent)
       indexes = Seq(
         IndexModel(Indexes.ascending("id"), IndexOptions().unique(true).name("id_Index")),
         IndexModel(Indexes.ascending("caseReference"), IndexOptions().unique(false).name("caseReference_Index")),
-        IndexModel(Indexes.ascending("type"), IndexOptions().unique(false).name("type_Index"))
+        IndexModel(Indexes.ascending("type"), IndexOptions().unique(false).name("type_Index")),
+        IndexModel(Indexes.descending("timestamp"), IndexOptions().unique(false).name("timestamp_Index"))
       )
     )
     with EventRepository

--- a/app/uk/gov/hmrc/bindingtariffclassification/repository/SearchMapper.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/repository/SearchMapper.scala
@@ -209,7 +209,6 @@ class SearchMapper @Inject() (appConfig: AppConfig) extends Mapper {
       case DECISION_START_DATE => "decision.effectiveStartDate"
       case APPLICATION_STATUS  => "application.status"
       case APPLICATION_TYPE    => "application.type"
-      case GOODS_NAME          => "application.goodName"
       case STATUS              => "status"
       case s                   => throw new IllegalArgumentException(s"cannot sort by field: $s")
     }

--- a/app/uk/gov/hmrc/bindingtariffclassification/sort/CaseSortField.scala
+++ b/app/uk/gov/hmrc/bindingtariffclassification/sort/CaseSortField.scala
@@ -26,6 +26,5 @@ object CaseSortField extends Enumeration {
   val DECISION_START_DATE = Value("decision-start-date")
   val APPLICATION_STATUS  = Value("application.status")
   val APPLICATION_TYPE    = Value("application.type")
-  val GOODS_NAME          = Value("application.goodName")
   val STATUS              = Value("status")
 }

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/BaseMongoIndexSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/BaseMongoIndexSpec.scala
@@ -20,7 +20,7 @@ import org.mongodb.scala.MongoCollection
 import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import uk.gov.hmrc.bindingtariffclassification.base.BaseSpec
 
-import scala.collection.JavaConverters.asScalaSetConverter
+import scala.collection.JavaConverters.{asScalaIteratorConverter, asScalaSetConverter, collectionAsScalaIterableConverter}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait BaseMongoIndexSpec extends BaseSpec {
@@ -36,7 +36,10 @@ trait BaseMongoIndexSpec extends BaseSpec {
           val indexFields = document.get("key").map(_.asDocument().keySet().asScala).getOrElse(Set.empty[String]).toSeq
           val name        = document.getString("name")
           val isUnique    = document.getBoolean("unique", false)
-          IndexModel(Indexes.ascending(indexFields: _*), IndexOptions().name(name).unique(isUnique))
+          val sorting =
+            document.get("key").map(_.asDocument().values().asScala.head.asInt32().getValue.toString).getOrElse("1")
+          val indexes = if (sorting == "1") Indexes.ascending(indexFields: _*) else Indexes.descending(indexFields: _*)
+          IndexModel(indexes, IndexOptions().name(name).unique(isUnique))
         })
     )
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseRepositorySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseRepositorySpec.scala
@@ -22,7 +22,7 @@ import org.mockito.BDDMockito.given
 import org.mongodb.scala.MongoWriteException
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.bson.{BsonDocument, BsonInt32}
-import org.mongodb.scala.model.Indexes.ascending
+import org.mongodb.scala.model.Indexes.{ascending, descending}
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -2363,6 +2363,8 @@ class CaseRepositorySpec
         IndexModel(ascending("_id"), IndexOptions().name("_id_")),
         IndexModel(ascending("reference"), IndexOptions().name("reference_Index").unique(true)),
         IndexModel(ascending("queueId"), IndexOptions().name("queueId_Index").unique(false)),
+        IndexModel(ascending("status"), IndexOptions().name("status_Index").unique(false)),
+        IndexModel(descending("createdDate"), IndexOptions().name("createdDate_Index").unique(false)),
         IndexModel(
           ascending("application.holder.eori"),
           IndexOptions().name("application.holder.eori_Index").unique(false)
@@ -2371,8 +2373,11 @@ class CaseRepositorySpec
           ascending("application.agent.eoriDetails.eori"),
           IndexOptions().name("application.agent.eoriDetails.eori_Index").unique(false)
         ),
-        IndexModel(ascending("daysElapsed"), IndexOptions().name("daysElapsed_Index").unique(false)),
         IndexModel(ascending("assignee.id"), IndexOptions().name("assignee.id_Index").unique(false)),
+        IndexModel(
+          ascending("application.type"),
+          IndexOptions().unique(false).name("application.type_Index")
+        ),
         IndexModel(
           ascending("decision.effectiveEndDate"),
           IndexOptions().name("decision.effectiveEndDate_Index").unique(false)
@@ -2381,7 +2386,7 @@ class CaseRepositorySpec
           ascending("decision.bindingCommodityCode"),
           IndexOptions().name("decision.bindingCommodityCode_Index").unique(false)
         ),
-        IndexModel(ascending("status"), IndexOptions().name("status_Index").unique(false)),
+        IndexModel(ascending("daysElapsed"), IndexOptions().name("daysElapsed_Index").unique(false)),
         IndexModel(ascending("keywords"), IndexOptions().name("keywords_Index").unique(false))
       )
 

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseSearchMapperSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/CaseSearchMapperSpec.scala
@@ -345,16 +345,6 @@ class CaseSearchMapperSpec extends BaseMongoIndexSpec {
       jsonMapper.sortBy(sort) shouldBe Json.obj("reference" -> -1)
     }
 
-    "sort by goods name and set direction descending" in {
-
-      val sort = CaseSort(
-        field     = Set(CaseSortField.GOODS_NAME),
-        direction = SortDirection.ASCENDING
-      )
-
-      jsonMapper.sortBy(sort) shouldBe Json.obj("application.goodName" -> 1)
-    }
-
     "sort by case status and set direction ascending" in {
 
       val sort = CaseSort(

--- a/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/EventRepositorySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffclassification/repository/EventRepositorySpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.bindingtariffclassification.repository
 
 import org.mongodb.scala.MongoWriteException
-import org.mongodb.scala.model.Indexes.ascending
+import org.mongodb.scala.model.Indexes.{ascending, descending}
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -286,6 +286,7 @@ class EventRepositorySpec
         IndexModel(ascending("id"), IndexOptions().name("id_Index").unique(true)),
         IndexModel(ascending("caseReference"), IndexOptions().name("caseReference_Index").unique(false)),
         IndexModel(ascending("type"), IndexOptions().name("type_Index").unique(false)),
+        IndexModel(descending("timestamp"), IndexOptions().name("timestamp_Index").unique(false)),
         IndexModel(ascending("_id"), IndexOptions().name("_id_"))
       )
 


### PR DESCRIPTION
### DDCE-3427

Added indexes for fields used in sorts from case collection `createdDate`, `application.type`. In events collection added `timestamp` index.
Have not added index for `application.status` as it's only available in a few case types.

**To Fix**
```
com.mongodb.MongoQueryException: Query failed with error code 96 and error message Executor error 
during find command :: caused by :: Sort operation used more than the maximum 33554432 bytes of RAM.
```

Updated most dependencies but have not addressed warning, to fix exception in production.